### PR TITLE
Reduce state size

### DIFF
--- a/components/ActorIcon.vue
+++ b/components/ActorIcon.vue
@@ -1,12 +1,14 @@
 <template>
   <img
-    :src="actor.imageUrl"
-    :title="actor.title"
+    :src="value.imageUrl"
+    :title="value.title"
     @error="imgError"
   >
 </template>
 
 <script lang="ts">
+import Raven from 'raven-js'
+
 class ActorImageError extends Error {
   constructor(message?: string) {
     super(message)
@@ -15,15 +17,21 @@ class ActorImageError extends Error {
 }
 export default {
   props: {
-    actor: { type: Object, required: true }
+    value: { type: Object, required: true }
   },
   methods: {
     imgError() {
-      this.$store.commit('setDefaultActorIcon', this.actor.actorId)
-
-      throw new ActorImageError(
-        `Image not found at ${this.actor.imageUrl}. (actor: ${this.actor.actorId})`
+      Raven.captureException(
+        new ActorImageError(
+          `Image not found at ${this.value.imageUrl}. (actor: ${this.value.actorId})`
+        ),
+        { level: 'warning' }
       )
+
+      this.$emit('input', {
+        ...this.value,
+        imageUrl: 'https://abs.twimg.com/sticky/default_profile_images/default_profile_200x200.png'
+      })
     }
   }
 }

--- a/helpers/ContentLoader.ts
+++ b/helpers/ContentLoader.ts
@@ -1,0 +1,101 @@
+import { DateTime } from 'luxon'
+
+const exclude = ['meta', 'anchors', 'date']
+
+const allEpisodes = async (app) => {
+  return await app
+    .$content('/episode')
+    .query({ exclude })
+    .getAll()
+}
+const allActors = async (app) => {
+  return await app
+    .$content('/actors')
+    .query({ exclude })
+    .getAll()
+}
+
+const excludeBody = (obj) => {
+  if (!obj) return obj
+  const { body, ...rest } = obj
+  return rest
+}
+
+class Content {
+  app = null
+  episodes: any[] = []
+  actors: any[] = []
+  actorMap = {}
+  actorEpisodeMap = {}
+  isLoaded = false
+
+  constructor(app) {
+    this.app = app
+  }
+  async load() {
+    if (this.isLoaded) return
+
+    this.episodes = (await allEpisodes(this.app)).map((episode) => ({
+      ...episode,
+      published: DateTime.fromSQL(episode.published).valueOf(),
+      id: episode.path.replace(/.*\/(.+)/, '$1')
+    }))
+
+    this.actors = await allActors(this.app)
+
+    this.actorMap = this.actors.reduce((map, actor) => {
+      return { ...map, [actor.actorId]: excludeBody(actor) }
+    }, {})
+
+    this.actorEpisodeMap = this.episodes.reduce((map, episode) => {
+      episode.actorIds.forEach((actorId) => {
+        map[actorId] = [...(map[actorId] || []), excludeBody(episode)]
+      })
+      return map
+    }, {})
+
+    this.isLoaded = true
+  }
+  async getHome() {
+    await this.load()
+    return this.episodes.map((episode) => excludeBody(this.episodeWithActors(episode)))
+  }
+  async getEpisodes() {
+    await this.load()
+    return this.episodes.map((episode) => this.episodeWithActors(episode))
+  }
+  async getEpisode(id) {
+    await this.load()
+    const episodeIndex = this.episodes.map((episode) => episode.id).indexOf(id)
+    const episode = this.episodes[episodeIndex]
+
+    return {
+      ...this.episodeWithActors(episode),
+      newer: excludeBody(this.episodes[episodeIndex - 1]),
+      older: excludeBody(this.episodes[episodeIndex + 1])
+    }
+  }
+  async getActors() {
+    await this.load()
+    return this.actors.map((actor) => excludeBody(this.actorWithEpisodes(actor)))
+  }
+  async getActor(id) {
+    await this.load()
+    const actor = this.actors.find((actor) => actor.actorId === id)
+
+    return this.actorWithEpisodes(actor)
+  }
+  episodeWithActors(episode) {
+    return {
+      ...episode,
+      actors: episode.actorIds.map((actorId) => this.actorMap[actorId])
+    }
+  }
+  actorWithEpisodes(actor) {
+    return {
+      ...actor,
+      episodes: this.actorEpisodeMap[actor.actorId] || []
+    }
+  }
+}
+export default Content

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -44,6 +44,8 @@ export default {
     // https://github.com/nuxt/nuxt.js/issues/2000
     this.twitterWidget = true
     this.$store.watch(state => state.searchText, this.onChangeQuery)
+    this.$store.app.$content('/episode').getAll()
+    this.$store.app.$content('/actors').getAll()
   },
   methods: {
     onChangeQuery(val) {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -193,7 +193,7 @@ const conf = {
   },
   rssItems: episodes.episode,
   loading: { color: '#3B8070' },
-  plugins: ['~plugins/vue-awesome.js']
+  plugins: ['~plugins/vue-awesome.js', '~plugins/content-loader.js']
 }
 
 if (!conf.dev) {

--- a/pages/actors/_id.vue
+++ b/pages/actors/_id.vue
@@ -42,17 +42,9 @@ export default {
   components: {
     ActorIcon
   },
-  asyncData({ store, route }) {
+  async asyncData({ app, params }) {
     return {
-      actor: store.getters.actorByPath(route.path)
-    }
-  },
-  mounted() {
-    this.$store.watch(state => state.actors, this.updateActor)
-  },
-  methods: {
-    updateActor() {
-      this.actor = this.$store.getters.actorByPath(this.$route.path)
+      actor: await app.$contentLoader.getActor(params.id)
     }
   },
   head() {

--- a/pages/actors/_id.vue
+++ b/pages/actors/_id.vue
@@ -3,7 +3,7 @@
 
     <header class="title">
       <ActorIcon
-        :actor="actor"
+        v-model="actor"
         class="icon"
       />
       <h1 class="actor-title"> {{ actor.title }} </h1>

--- a/pages/actors/index.vue
+++ b/pages/actors/index.vue
@@ -26,11 +26,16 @@ export default {
   },
   computed: {
     sortedActors() {
-      return [...this.$store.getters.actorsWithEpisodes].sort((a, b) => {
+      return this.actors.sort((a, b) => {
         // sort by appearCount or lastAppearDate
         const countDiff = b.episodes.length - a.episodes.length
         return countDiff !== 0 ? countDiff : b.episodes[0].published - a.episodes[0].published
       })
+    }
+  },
+  async asyncData({ app }) {
+    return {
+      actors: await app.$contentLoader.getActors()
     }
   },
   head() {

--- a/pages/actors/index.vue
+++ b/pages/actors/index.vue
@@ -2,13 +2,13 @@
   <div>
     <ul class="actor-list">
       <li
-        v-for="actor in sortedActors"
+        v-for="(actor, i) in sortedActors"
         :key="actor.title"
         class="actor-list-item"
       >
         <nuxt-link :to="actor.permalink">
           <ActorIcon
-            :actor="actor"
+            v-model="sortedActors[i]"
           />
           <p>{{ actor.title }} ({{ actor.episodes.length }})</p>
         </nuxt-link>

--- a/pages/episode/_id.vue
+++ b/pages/episode/_id.vue
@@ -80,9 +80,9 @@ export default {
       return EpisodeHelper.desc(episode)
     }
   },
-  asyncData({ store, route }) {
+  async asyncData({ app, params }) {
     return {
-      episode: store.getters.episodeByPath(route.path)
+      episode: await app.$contentLoader.getEpisode(params.id)
     }
   },
   computed: {
@@ -109,7 +109,6 @@ export default {
   },
   mounted() {
     this.loadTwitterWidget()
-    this.$store.watch(state => state.actors, this.updateEpisode)
   },
   updated() {
     this.loadTwitterWidget()

--- a/pages/episode/_id.vue
+++ b/pages/episode/_id.vue
@@ -25,13 +25,13 @@
         <h2>出演者</h2>
         <ul class="actor-list">
           <li
-            v-for="actor in episode.actors"
+            v-for="(actor,i) in episode.actors"
             :key="actor.title"
             class="actor-list-item"
           >
             <nuxt-link :to="actor.permalink">
               <ActorIcon
-                :actor="actor"
+                v-model="episode.actors[i]"
               />
               <p>{{ actor.title }}</p>
             </nuxt-link>

--- a/pages/episode/index.vue
+++ b/pages/episode/index.vue
@@ -39,9 +39,9 @@
             <div class="episode-actor">
               <ActorIcon
                 class="episode-actor-item"
-                v-for="actor in episode.actors"
+                v-for="(actor, i) in episode.actors"
                 :key="actor.actorId"
-                :actor="actor"
+                v-model="episode.actors[i]"
               />
             </div>
 

--- a/pages/episode/index.vue
+++ b/pages/episode/index.vue
@@ -7,7 +7,7 @@
     </header>
 
     <div v-if="queries.length > 0">
-      <icon name="search" scale="1.5"></icon> 検索中:（{{`${episodes.length} / ${$store.state.episodes.length}  件`}}）
+      <icon name="search" scale="1.5"></icon> 検索中:（{{`${filteredEpisodes.length} / ${episodes.length}  件`}}）
       <button
         v-for="(query, i) in queries"
         :key="query"
@@ -19,11 +19,11 @@
     </div>
 
     <main>
-      <div class="card" v-if="episodes.length > 0">
+      <div class="card" v-if="filteredEpisodes.length > 0">
         <nuxt-link
-          :to="episode.permalink"
-          v-for="episode in episodes"
+          v-for="episode in filteredEpisodes"
           :key="episode.permalink"
+          :to="episode.permalink"
           :id="'ep' + episode.id"
           class="episode"
         >
@@ -78,11 +78,28 @@ export default {
   },
   computed: {
     ...mapGetters(['queries']),
-    episodes() {
-      return this.$store.getters.filteredEpisodes.map(episode => ({
+    episodesForFilter() {
+      return this.episodes.map(episode => ({
         ...episode,
-        actors: episode.actorIds.map(actorId => this.$store.getters.actorsMap[actorId])
+        bodyText: episode.body && episode.body.replace(/<[^>]*?>/g, ' ')
       }))
+    },
+    filteredEpisodes() {
+      if (this.queries.length === 0) return this.episodes
+      return this.episodesForFilter.filter(ep =>
+        this.queries.every(q => {
+          const r = new RegExp(q, 'i')
+          return (
+            ep.actorIds.some(a => a.match(r)) ||
+            ep.topics.some(t => t.match(r) || ep.title.match(r) || ep.bodyText.match(r))
+          )
+        })
+      )
+    }
+  },
+  async asyncData({ app }) {
+    return {
+      episodes: await app.$contentLoader.getEpisodes()
     }
   },
   filters: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -60,17 +60,9 @@ export default {
   components: {
     ActorIcon
   },
-  asyncData({ store }) {
+  async asyncData({ app }) {
     return {
-      episodes: store.getters.episodesWithActors
-    }
-  },
-  mounted() {
-    this.$store.watch(state => state.actors, this.updateEpisodes)
-  },
-  methods: {
-    updateEpisodes() {
-      this.episodes = this.$store.getters.episodesWithActors
+      episodes: await app.$contentLoader.getHome()
     }
   },
   computed: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -32,9 +32,9 @@
           <div class="actor-list">
             <ActorIcon
               class="actor-list-item"
-              v-for="actor in episode.actors"
+              v-for="(actor, i) in episode.actors"
               :key="actor.actorId"
-              :actor="actor"
+              v-model="episode.actors[i]"
             />
           </div>
         </article>

--- a/plugins/content-loader.js
+++ b/plugins/content-loader.js
@@ -1,0 +1,5 @@
+import ContentLoader from '~/helpers/ContentLoader.ts'
+
+export default ({ app }, inject) => {
+  inject('contentLoader', new ContentLoader(app))
+}

--- a/store/index.js
+++ b/store/index.js
@@ -1,115 +1,13 @@
-import Vue from 'vue'
-import { DateTime } from 'luxon'
-
-const defaultProfileImageURL =
-  'https://abs.twimg.com/sticky/default_profile_images/default_profile_200x200.png'
-const regularPath = (val) => val.replace(/\/$/, '')
-
 export const state = () => ({
-  searchText: '',
-  episodes: [],
-  actors: []
+  searchText: ''
 })
 export const getters = {
   queries: (state) => {
     return state.searchText.split(/\s+/).filter((s) => s !== '')
-  },
-  actorToEpisodeMap: (state) => {
-    return state.episodes.reduce((map, episode) => {
-      episode.actorIds.forEach((actorId) => {
-        map[actorId] = [...(map[actorId] || []), episode]
-      })
-      return map
-    }, {})
-  },
-  actorsWithEpisodes: (state, getters) => {
-    return state.actors.map((actor) => ({
-      ...actor,
-      episodes: getters.actorToEpisodeMap[actor.actorId] || []
-    }))
-  },
-  actorsMap: (state) => {
-    return state.actors.reduce((map, actor) => ({ ...map, [actor.actorId]: actor }), {})
-  },
-  actorByPath: (state, getters) => (path) => {
-    const rpath = regularPath(path)
-    return getters.actorsWithEpisodes.find((actor) => actor.path === rpath)
-  },
-  episodesWithActors: (state, getters) => {
-    return state.episodes.map((episode) => ({
-      ...episode,
-      actors: episode.actorIds.map((actorId) => getters.actorsMap[actorId])
-    }))
-  },
-  episodeByPath: (state, getters) => (path) => {
-    const rpath = regularPath(path)
-    const episodes = getters.episodesWithActors
-    const i = episodes.map((episode) => episode.path).indexOf(rpath)
-    const episode = episodes[i]
-    return {
-      ...episode,
-      newer: state.episodes[i - 1],
-      older: state.episodes[i + 1]
-    }
-  },
-  episodesForFilter: (state) => {
-    return state.episodes.map((episode) => ({
-      ...episode,
-      bodyText: episode.body.replace(/<[^>]*?>/g, ' ')
-    }))
-  },
-  filteredEpisodes: (state, getters) => {
-    if (getters.queries.length === 0) return state.episodes
-    return getters.episodesForFilter.filter((ep) =>
-      getters.queries.every((q) => {
-        const r = new RegExp(q, 'i')
-        return (
-          ep.actorIds.some((a) => a.match(r)) ||
-          ep.topics.some((t) => t.match(r) || ep.title.match(r) || ep.bodyText.match(r))
-        )
-      })
-    )
   }
 }
 export const mutations = {
-  setDefaultActorIcon(state, payload) {
-    const i = state.actors.findIndex((actor) => actor.actorId === payload)
-    if (i < 0) return
-    Vue.set(state.actors, i, {
-      ...state.actors[i],
-      imageUrl: defaultProfileImageURL
-    })
-  },
   searchText(state, payload) {
     state.searchText = payload
-  },
-  episodes(state, payload) {
-    state.episodes = payload
-  },
-  actors(state, payload) {
-    state.actors = payload
-  }
-}
-export const actions = {
-  async nuxtServerInit({ commit }, { req, app, query }) {
-    let episodes = await app
-      .$content('/episode')
-      .query({ exclude: ['meta', 'anchors', 'date'] })
-      .getAll()
-
-    episodes = episodes.map((episode) => ({
-      ...episode,
-      published: DateTime.fromSQL(episode.published).valueOf(),
-      id: episode.path.replace(/^.*\//, '')
-    }))
-
-    const actors = await app
-      .$content('/actors')
-      .query({ exclude: ['meta', 'anchors', 'date'] })
-      .getAll()
-
-    commit('episodes', episodes)
-    commit('actors', actors)
-    commit('searchText', query.q || '')
   }
 }


### PR DESCRIPTION
- nuxtServerInitで入れた初期stateは、generate時に各ページに書き出されサイズが肥大化してしまうため必要なものだけに最適化する
- 各ページに必要なデータだけ取得するcontent loader pluginを作り、asyncDataで読み込んでServer側初期状態を用意して初回読み込みを速くする
- stateにデータが無く、遷移時に動的にデータ取得すると遅いので、client初期化時(mounted)に追加でjsonDataを全て読み込む