### PR TITLE
Prevent auto-zoom in input on iOS

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -65,7 +65,7 @@ p {
 }
 small {
   color: #637381;
-  font-size: .8rem;
+  font-size: 0.8rem;
 }
 blockquote {
   color: rgb(28, 32, 34);
@@ -95,12 +95,21 @@ $listItemMargin: 1.2em;
     & li {
       position: relative;
       &:before {
-        content: "▶";
+        content: '▶';
         display: block;
         position: absolute;
         left: -$listItemMargin;
         color: #aed9bb;
       }
     }
+  }
+}
+// Prevent auto-zoom in input on iOS:
+// https://stackoverflow.com/a/16255670
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  select,
+  textarea,
+  input {
+    font-size: 16px !important;
   }
 }


### PR DESCRIPTION
https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone/16255670#16255670

iOSではinput欄のfont-sizeが16px未満だとフォーカス時に自動的にズームする模様。
input系のfont-sizeを強制的に16pxにしてズームしないように対応する。
