### PR TITLE
fix: Nuxt server error

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@miyaoka/vue-touch-range": "^1.0.1",
-    "@nuxtjs/axios": "latest",
+    "@nuxtjs/axios": "^4.3.0",
     "@nuxtjs/google-analytics": "^2.0.2",
     "@nuxtjs/pwa": "^2.0.5",
     "@nuxtjs/sentry": "^0.2.0",


### PR DESCRIPTION
`nuxtent`と`axios`がlatestなので、多分クリーンインストールすると、以下になる。

![2018-01-30 18 43 51](https://user-images.githubusercontent.com/2557813/35561894-1562b732-05f5-11e8-95c8-d00b3a4200da.png)

`axios` をv4.3.0を指定すると僕の環境では改善されてる