### PR TITLE
Apply lazyload to twitter-timeline

### DIFF
--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -17,11 +17,13 @@
         ><icon name="pencil-square-o" scale="1.1"></icon>お便りを送る</FeedbackForm>
       </div>
       <div class="timeline">
-        <TwitterTimeline
-          :widgetId="'956788689086046208'"
-          :q="'#soussune'"
-          :rt="false"
-        />
+        <lazy-component>
+          <TwitterTimeline
+            :widgetId="'956788689086046208'"
+            :q="'#soussune'"
+            :rt="false"
+          />
+        </lazy-component>
       </div>
     </div>
   </footer>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -204,7 +204,7 @@ const conf = {
       shouldSendCallback: () => process.env.NODE_ENV === 'production'
     }
   },
-  plugins: ['~plugins/vue-awesome.js', '~plugins/content-loader.js']
+  plugins: ['~plugins/vue-awesome.js', '~plugins/content-loader.js', '~plugins/vue-lazyload.js']
 }
 
 module.exports = conf

--- a/package-lock.json
+++ b/package-lock.json
@@ -10906,6 +10906,11 @@
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.2.4.tgz",
       "integrity": "sha512-e+ThJMYmZg4D9UnrLcr6LQxGu6YlcxkrmZGPCyIN4malcNhdeGGKxmFuM5y6ICMJJxQywLfT8MM1rYZr4LpeLw=="
     },
+    "vue-lazyload": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/vue-lazyload/-/vue-lazyload-1.1.4.tgz",
+      "integrity": "sha512-bE+Jyl9aJo2Ok30MC8+Gq/sSIhsErRWNVzmzSStPuZrEiaJ1d7MHp8jJB9rB3DT4lim8T2QxLgT13+7X8hzfoA=="
+    },
     "vue-loader": {
       "version": "13.6.0",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-13.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "nuxtent": "^1.2.2",
     "rss": "^1.2.2",
     "vue-awesome": "^2.3.4",
+    "vue-lazyload": "^1.1.4",
     "xml-escape": "^1.1.0"
   },
   "scripts": {

--- a/plugins/vue-lazyload.js
+++ b/plugins/vue-lazyload.js
@@ -1,0 +1,6 @@
+import Vue from 'vue'
+import VueLazyload from 'vue-lazyload'
+
+Vue.use(VueLazyload, {
+  lazyComponent: true
+})


### PR DESCRIPTION
# Before

<img width="740" alt="2018-01-31 22 09 10" src="https://user-images.githubusercontent.com/1443118/35624804-6d4d9320-06d3-11e8-92ff-9a06ff8e2077.png">

# After

<img width="665" alt="2018-01-31 22 08 50" src="https://user-images.githubusercontent.com/1443118/35624851-8d2ac064-06d3-11e8-9e55-658b69e21225.png">

Performance: 67→72
