### PR TITLE
Add px to style object value

### DIFF
--- a/components/AudioControlButton.vue
+++ b/components/AudioControlButton.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="audio-control-button"
     :style="{
-      width: buttonSize + 'px',
-      height: buttonSize + 'px'
+      width: buttonSize,
+      height: buttonSize
     }">
     <AudioPlayingIcon
       class="icon"

--- a/components/AudioControlButton.vue
+++ b/components/AudioControlButton.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="audio-control-button"
     :style="{
-      width: buttonSize,
-      height: buttonSize
+      width: buttonSize + 'px',
+      height: buttonSize + 'px'
     }">
     <AudioPlayingIcon
       class="icon"

--- a/components/ProgressCircle.vue
+++ b/components/ProgressCircle.vue
@@ -3,8 +3,8 @@
     version="1.1"
     xmlns="http://www.w3.org/2000/svg"
     :style="{
-      width: size,
-      height: size
+      width: size + 'px',
+      height: size + 'px'
     }"
   >
     <circle


### PR DESCRIPTION
## 現象

Firefox環境でのプレイヤーボタン表示不具合。

https://twitter.com/piro_or/status/974696506941890561

![image](https://user-images.githubusercontent.com/1443118/37537163-0c264a80-2990-11e8-9748-61b746129f43.png)

## 原因

#49 によるスタイル設定がFirefoxだと適用されてない模様。

https://github.com/soussune/soussune.com/blob/23f208744bcc76472416b820047cc0f05d219e4f/components/AudioControlButton.vue#L2-L6

vueのObject style bindingsは数値のみでOKと認識していたが、どうもchromeが上手く解釈してくれていただけっぽい？ 

https://github.com/soussune/soussune.com/blob/de203e1d4e6ea0f19296f165e825b7c2efd5fbf4/components/ProgressCircle.vue#L2-L9

→問題はこちらのsvgのwidthとheight部分なので、通常のDOMと違いブラウザによって解釈に差異があった模様。

## 対策

https://vuejs.org/v2/guide/class-and-style.html#Binding-Inline-Styles

```
<div v-bind:style="{ color: activeColor, fontSize: fontSize + 'px' }"></div>
```

公式ドキュメントでも'px'の追加が明示されているので、追加して対応する。
