### PR TITLE
Set individual ogp title and desc.

### DIFF
--- a/pages/actors/_id.vue
+++ b/pages/actors/_id.vue
@@ -95,7 +95,19 @@ export default {
   },
   head() {
     return {
-      title: this.actor.title
+      title: this.actor.title,
+      meta: [
+        {
+          property: 'og:title',
+          content: `soussune - ${this.actor.title}`,
+          hid: 'ogTitle'
+        },
+        {
+          property: 'og:description',
+          content: this.actor.description,
+          hid: 'ogDesc'
+        }
+      ]
     }
   }
 }

--- a/pages/actors/_id.vue
+++ b/pages/actors/_id.vue
@@ -106,6 +106,11 @@ export default {
           property: 'og:description',
           content: this.actor.description,
           hid: 'ogDesc'
+        },
+        {
+          property: 'og:image',
+          content: this.actor.imageUrl,
+          hid: 'ogImage'
         }
       ]
     }

--- a/pages/actors/index.vue
+++ b/pages/actors/index.vue
@@ -64,7 +64,14 @@ export default {
   },
   head() {
     return {
-      title: '出演者'
+      title: '出演者',
+      meta: [
+        {
+          property: 'og:title',
+          content: `soussune - 出演者`,
+          hid: 'ogTitle'
+        }
+      ]
     }
   }
 }

--- a/pages/episode/_id.vue
+++ b/pages/episode/_id.vue
@@ -22,7 +22,7 @@
 
       <div class="desc">
         <h2>内容紹介</h2>
-        {{ episode | desc }}
+        {{ desc }}
       </div>
 
       <div class="actors">
@@ -83,9 +83,6 @@ export default {
       return DateTime.fromMillis(episode.published, { zone: 'Asia/Tokyo' }).toFormat(
         'yyyy年MM月dd日'
       )
-    },
-    desc(episode) {
-      return EpisodeHelper.desc(episode)
     }
   },
   async asyncData({ app, params }) {
@@ -94,6 +91,9 @@ export default {
     }
   },
   computed: {
+    desc() {
+      return EpisodeHelper.desc(this.episode)
+    },
     src(): string {
       return (
         'http://cdn.soussune.com.s3-ap-northeast-1.amazonaws.com/audio' + this.episode.audioFilePath
@@ -114,7 +114,19 @@ export default {
   },
   head() {
     return {
-      title: this.episode.title
+      title: this.episode.title,
+      meta: [
+        {
+          property: 'og:title',
+          content: `soussune - ${this.episode.title}`,
+          hid: 'ogTitle'
+        },
+        {
+          property: 'og:description',
+          content: this.desc,
+          hid: 'ogDesc'
+        }
+      ]
     }
   },
   mounted() {

--- a/pages/episode/index.vue
+++ b/pages/episode/index.vue
@@ -133,7 +133,14 @@ export default {
   },
   head() {
     return {
-      title: 'エピソード'
+      title: 'エピソード',
+      meta: [
+        {
+          property: 'og:title',
+          content: `soussune - エピソード`,
+          hid: 'ogTitle'
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
episode、actorの各ページにogpのタイトルとdescを設定する。

## episode
### list
<img width="454" alt="2018-03-19 1 58 09" src="https://user-images.githubusercontent.com/1443118/37568519-5aa0da92-2b19-11e8-8834-7ea617c0986d.png">

### item
<img width="460" alt="2018-03-19 1 59 34" src="https://user-images.githubusercontent.com/1443118/37568502-35811c5e-2b19-11e8-971d-1d0c64b0c6fd.png">


## actor 
### list 
<img width="455" alt="2018-03-19 1 58 30" src="https://user-images.githubusercontent.com/1443118/37568505-362e6878-2b19-11e8-82f3-3d538a88b42a.png">

### item
<img width="456" alt="2018-03-19 1 58 52" src="https://user-images.githubusercontent.com/1443118/37568504-35caf784-2b19-11e8-82f5-373f07827a61.png">

actorはogp画像も設定していいかも？

<img width="457" alt="2018-03-19 2 12 30" src="https://user-images.githubusercontent.com/1443118/37568618-0456e18e-2b1b-11e8-87f1-42e35c1c972e.png">

<img width="457" alt="2018-03-19 2 13 54" src="https://user-images.githubusercontent.com/1443118/37568635-470b069a-2b1b-11e8-812f-bde3e5a0dcaa.png">

設定してみたけど、twitter画像だとなんかちゃんと表示されない…