### PR TITLE
Prevent overflow episode tags

### DIFF
--- a/src/pages/episode/index.vue
+++ b/src/pages/episode/index.vue
@@ -205,11 +205,11 @@ $ep-hover-clr: $clr-black-dd;
   article {
     display: grid;
     grid-template-areas: 'header actor' 'topic date';
-    grid-template-columns: 1fr 200px;
+    grid-template-columns: minmax(0, 1fr) 200px;
     box-sizing: content-box;
     padding: 0.5rem;
     @include mq() {
-      grid-template-columns: 1fr 100px;
+      grid-template-columns: minmax(0, 1fr) 100px;
     }
   }
   &-header {


### PR DESCRIPTION
#91 

06947ed でspanタグ内の空白を削ったところ、改行されなくなった不具合。

タグのコンテナはgridにより表示幅を設定していて、単に1frだとおかしくなる模様。
minmaxで指定して対応する