### PR TITLE
Set actor title to page and og title too

### DIFF
--- a/src/pages/actors/_id.vue
+++ b/src/pages/actors/_id.vue
@@ -8,7 +8,7 @@
         :size="200"
         class="actor-icon"
       />
-      <h1 class="actor-title">{{ actor.title }}<span v-if="actor.realname">&nbsp;({{ actor.realname }})</span></h1>
+      <h1 class="actor-title">{{ actorCombinedName }}</h1>
     </header>
 
     <section class="accounts" v-if="actor.accounts">
@@ -94,13 +94,18 @@ export default {
       return serviceInfo[service] && serviceInfo[service].label
     }
   },
+  computed: {
+    actorCombinedName() {
+      return this.actor.title + (this.actor.realname ? ` (${this.actor.realname})` : '')
+    }
+  },
   head() {
     return {
-      title: this.actor.title,
+      title: this.actorCombinedName,
       meta: [
         {
           property: 'og:title',
-          content: `soussune - ${this.actor.title}`,
+          content: `soussune - ${this.actorCombinedName}`,
           hid: 'ogTitle'
         },
         {


### PR DESCRIPTION
#93 の対応ではh1タグの部分のみで、ページタイトルとog:titleはそのままだったので、適用するように改修