### PR TITLE
Optimize contentful image settings

### DIFF
--- a/src/components/ActorIcon.vue
+++ b/src/components/ActorIcon.vue
@@ -14,7 +14,12 @@ export default {
   },
   computed: {
     src() {
-      const params = { w: this.size, h: this.size }
+      const params = {
+        w: this.size,
+        h: this.size,
+        fm: 'jpg',
+        fl: 'progressive'
+      }
       return [
         this.actor.imageUrl,
         Object.keys(params)


### PR DESCRIPTION
https://www.webpagetest.org/performance_optimization.php?test=181025_HQ_0a537e508d30829ab256cfac9fdaa365&run=3#first_byte_time

## before

![image](https://user-images.githubusercontent.com/1443118/47516857-7cddd280-d8c1-11e8-84a3-17e7773ea8d7.png)

## after

![image](https://user-images.githubusercontent.com/1443118/47517418-12c62d00-d8c3-11e8-8002-bd33305b6445.png)

- compressの設定はcontentfulに無かったのでprogressive設定のみ
- qualityを下げてもcompressの評価は上がらず
